### PR TITLE
fix: monitoring artifact sizes with GoReleaser

### DIFF
--- a/goreleaser/default.yml
+++ b/goreleaser/default.yml
@@ -6,6 +6,8 @@ before:
     - go mod tidy
     - git --no-pager diff --exit-code go.mod go.sum
 
+report_sizes: true
+
 gomod:
   proxy: true
 

--- a/goreleaser/verifiable.yml
+++ b/goreleaser/verifiable.yml
@@ -6,6 +6,8 @@ before:
     - go mod tidy
     - git --no-pager diff --exit-code go.mod go.sum
 
+report_sizes: true
+
 gomod:
   proxy: true
 


### PR DESCRIPTION
The `report_sizes` section in GoReleaser allows you to generate a **detailed size report** for all release artifacts. This feature is invaluable for tracking artifact growth, maintaining size limits, and troubleshooting issues.

---

### Example Configuration

```yaml
report_sizes: true
```

Enabling this setting generates a report that lists the sizes of all artifacts produced during the release process.

---

### Key Benefits

1. **Tracking Binary Growth**
   Gain insights into how the sizes of your artifacts evolve over time. This is particularly useful for identifying trends in binary growth as your project scales.

2. **Maintaining Size Limits**
   Monitor artifact sizes to ensure they remain within acceptable thresholds, which is especially important for projects with strict size constraints.

3. **Debugging Issues**
   Quickly identify unexpected increases in artifact size that could indicate bugs, inefficient code, or unintentional inclusions.

---

# Quoting the GoReleaser documentation:

- https://goreleaser.com/customization/reportsizes/

## Report Sizes

You might want to enable this if you want to keep an eye on your binary/package
sizes.

It'll report the size of each artifact of the following types to the build
output, as well as on `dist/artifacts.json`:

- `Binary`
- `UniversalBinary`
- `UploadableArchive`
- `PublishableSnapcraft`
- `LinuxPackage`
- `CArchive`
- `CShared`
- `Header`

Here's the available configuration options:

```yaml title=".goreleaser.yaml"
# Whether to enable the size reporting or not.
report_sizes: true
```
