### PR TITLE
fix: replace to archives.formats from archives.format

### DIFF
--- a/goreleaser/default.yml
+++ b/goreleaser/default.yml
@@ -37,7 +37,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
-  - format: binary
+  - formats: binary
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     builds_info:
       mtime: "{{ .CommitDate }}"

--- a/goreleaser/verifiable.yml
+++ b/goreleaser/verifiable.yml
@@ -37,7 +37,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
-  - format: binary
+  - formats: binary
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     builds_info:
       mtime: "{{ .CommitDate }}"


### PR DESCRIPTION
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
